### PR TITLE
Add PIN validation recommendations

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -2,6 +2,7 @@
   "contributors": [
     "expede",
     "galligan",
-    "boisterouscoder"
+    "boisterouscoder",
+    "bgins"
   ]
 }

--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -3,6 +3,7 @@ AES
 AKE
 API's
 AWAKE's
+backoff
 Bluesky
 CAs
 Cleartext

--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -3,7 +3,7 @@ AES
 AKE
 API's
 AWAKE's
-backoff
+AcknowledgementS
 Bluesky
 CAs
 Cleartext
@@ -52,6 +52,7 @@ att
 aud
 auth
 awakeTag
+backoff
 bitLength
 bobPk
 cleartext

--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -3,7 +3,7 @@ AES
 AKE
 API's
 AWAKE's
-AcknowledgementS
+Acknowledgements
 Bluesky
 CAs
 Cleartext

--- a/Notices.md
+++ b/Notices.md
@@ -17,6 +17,7 @@ A Licensee may consent to accepting the current Community Specification License 
 | Brooklyn Zelenka | @expede | 0.1.0 or later |
 | Matt Galligan | @galligan | 0.1.0 or later |
 | Savannah Jackson | @boisterouscoder | 0.1.0 or later |
+| Brian Ginsburg | @bgins | 0.1.0 or later |
 
 ## Withdrawals
 

--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ At this stage, the Responder has been validated, but the Requestor is still untr
 
 The Requestor MUST provide the proof of authorization set by the Responder payload in [§3.3.2](#332-validation-ucan). The RECOMMENDED authorization methods are PIN validation (`pin`) and UCAN (`ucan`). Note that if the Requestor does not know how to respond to fulfill an authorization method, the AWAKE connection MUST fail with an [`unknown-challenge` message](#62-unknown-challenge-error).
 
+When using PIN validation, it is RECOMMENDED that the handshake fail after a maximum number of failed validation attempts, or the attempts be rate limited with exponential backoff.
+
 ### 3.4.1 Payload
 
 This message MUST be encrypted with the first AES output of the AWAKE [KDF](#143-diffie-hellman-key-derivation), using the initial chain secret established in [§3.3](#33-responder-establishes-point-to-point-session).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Authors
 
+* [Brian Ginsburg](https://github.com/bgins), [Fission](https://fission.codes)
 * [Daniel Holmgren](https://github.com/dholms), [Bluesky](https://blueskyweb.xyz/)
 * [Quinn Wilton](https://github.com/QuinnWilton), [Fission](https://fission.codes)
 * [Brooklyn Zelenka](https://github.com/expede), [Fission](https://fission.codes)

--- a/README.md
+++ b/README.md
@@ -792,5 +792,4 @@ Signal's deployment targets have complete control over their cryptographic stack
 
 # 8. Acknowledgements
 
-
 Many thanks to [Brian Ginsburg](https://github.com/bgins) for his exploration of AWAKE and suggestion to recommend backoff on PIN attempts.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 ## Authors
 
-* [Brian Ginsburg](https://github.com/bgins), [Fission](https://fission.codes)
 * [Daniel Holmgren](https://github.com/dholms), [Bluesky](https://blueskyweb.xyz/)
 * [Quinn Wilton](https://github.com/QuinnWilton), [Fission](https://fission.codes)
 * [Brooklyn Zelenka](https://github.com/expede), [Fission](https://fission.codes)
@@ -791,3 +790,7 @@ The [Signal Protocol](https://github.com/signalapp/libsignal) heavily influenced
 
 Signal's deployment targets have complete control over their cryptographic stack, and makes use of algorithms like 3XDH based on Curve25519. The AWAKE threat model includes browser application security that requires non-extractable keys, and at time of writing very few of these primitives are available.
 
+# 8. Acknowledgements
+
+
+Many thanks to [Brian Ginsburg](https://github.com/bgins) for his exploration of AWAKE and suggestion to recommend backoff on PIN attempts.


### PR DESCRIPTION
This PR adds recommendations around PIN validation security. 

Specifically it recommends that the handshake should fail after a maximum number of failed attempts. Alternatively, attempts might be rate limited with exponential backoff.